### PR TITLE
Provide the stack for transports on debug builds

### DIFF
--- a/addons/hanpeki_godot_logger/transports/logger_assert_transport.gd
+++ b/addons/hanpeki_godot_logger/transports/logger_assert_transport.gd
@@ -11,9 +11,6 @@
 ##
 class_name HanpekiLoggerAssertTransport extends HanpekiLogger.Transport
 
-## By default, ERROR and FATAL levels will call assert to stop the execution of the game
-const DEFAULT_LEVELS = [HanpekiLogger.ERROR, HanpekiLogger.FATAL]
-
 ## Levels that will call [code]assert(false, data.msg)[/code]
 var _assert_levels: Array[int]
 
@@ -23,8 +20,10 @@ var _assert_levels: Array[int]
 ##
 static func create(options: Options = null) -> HanpekiLoggerAssertTransport:
 	var instance = HanpekiLoggerAssertTransport.new()
+	if !options:
+		options = Options.new()
 	instance.set_options(options)
-	instance._assert_levels = DEFAULT_LEVELS if options == null else options.assert_levels
+	instance._assert_levels = options.assert_levels
 	return instance
 
 
@@ -36,4 +35,4 @@ func process(data: HanpekiLogger.MsgData) -> void:
 class Options:
 	extends Transport.Options
 	## Levels that will call [code]assert(false, data.msg)[/code]
-	var assert_levels: Array[int]
+	var assert_levels: Array[int] = [HanpekiLogger.ERROR, HanpekiLogger.FATAL]

--- a/addons/hanpeki_godot_logger/transports/logger_console_transport.gd
+++ b/addons/hanpeki_godot_logger/transports/logger_console_transport.gd
@@ -4,11 +4,9 @@
 ##
 class_name HanpekiLoggerConsoleTransport extends HanpekiLogger.Transport
 
-const DEFAULT_FORMATTING = true
-
 ## Whether to use formatting or not.
 ## Note that when formatting is enabled, spaces between elements are added in the BBTags
-var _formatting: bool = DEFAULT_FORMATTING
+var _formatting: bool
 ## Format to apply to the time as a BBTag with [code]{time}[/code] replaced
 var _datetime_format: String = "[bgcolor=#333033][color=grey] {time} [/color][/bgcolor]"
 ## Formats to apply to the levels as a BBTag with [code]{level}[/code] replaced
@@ -22,10 +20,12 @@ var _level_formats: Dictionary[int, String] = {
 }
 ## Formats to apply to the levels as a BBTag with [code]{ns}[/code] replaced
 var _ns_formats: Dictionary[StringName, String] = {}
-## Color to display when an unregistered level is used
+## Format to apply when an unregistered level is used as a BBTag with [code]{level}[/code] replaced
 var _level_default_format = "[{level}]"
-## Color to display when an unregistered namespace is used
+## Format to apply when an unregistered namespace is used as a BBTag with [code]{ns}[/code] replaced
 var _ns_default_format = "[bgcolor=#335][color=#eee] {ns} [/color][/bgcolor]"
+## Format to display when the stack is logged as a BBTag with [code]{stack}[/code] replaced
+var _stack_format = "[color=#99a]{stack}[/color]"
 
 
 ##
@@ -33,37 +33,64 @@ var _ns_default_format = "[bgcolor=#335][color=#eee] {ns} [/color][/bgcolor]"
 ##
 static func create(options: Options = null) -> HanpekiLoggerConsoleTransport:
 	var instance = HanpekiLoggerConsoleTransport.new()
+	if !options:
+		options = Options.new()
 	instance.set_options(options)
-	instance._formatting = DEFAULT_FORMATTING if options == null else options.formatting
+	instance._formatting = options.formatting
 	return instance
 
 
 func process(data: HanpekiLogger.MsgData) -> void:
 	var time = _get_time_str(data)
+
 	if _formatting:
 		var t = _datetime_format.replace("{time}", time)
 		var level = _format_level(data)
-		var ns = "" if data.ns == HanpekiLogger.NS_UNDEFINED else _format_ns(data)
-		print_rich("%s%s%s%s" % [t, level, ns, data.msg])
+		print_rich("%s%s%s%s%s" % [t, level, _format_ns(data), data.msg, _format_stack(data)])
 	else:
 		var ns = "" if data.ns == HanpekiLogger.NS_UNDEFINED else "[%s]" % data.ns
-		print("%s %s[%s] %s" % [time, data.level_name, ns, data.msg])
+		print("%s %s[%s] %s%s" % [time, data.level_name, ns, data.msg, _get_stack_str(data)])
 
 
+##
+## Set the format to use when printing the level name, as a template string
+## accepting BBTags, with the [code]{level}[/code] placeholder.
+##
 func set_level_format(level: int, format: String) -> void:
 	_level_formats[level] = format
 
 
+##
+## Set the format to use when printing a namespace name without an explicit format configured,
+## as a template string accepting BBTags with the [code]{level}[/code] placeholder.
+##
 func set_level_default_format(format: String) -> void:
 	_level_default_format = format
 
 
+##
+## Set the format to use when printing a namespace name, as a template string
+## accepting BBTags, with the [code]{ns}[/code] placeholder.
+##
 func set_ns_format(ns: StringName, format: String) -> void:
 	_ns_formats[ns] = format
 
 
+##
+## Set the format to use when printing a level name without a format configured,
+## (usually custom levels), as a template string accepting BBTags,
+## with the [code]{level}[/code] placeholder.
+##
 func set_ns_default_format(format: String) -> void:
 	_ns_default_format = format
+
+
+##
+## Set the format to use when printing a stack (if configured to do so and available),
+## as a template string accepting BBTags, with the [code]{stack}[/code] placeholder.
+##
+func set_stack_format(format: String) -> void:
+	_stack_format = format
 
 
 func _format_level(data: HanpekiLogger.MsgData) -> String:
@@ -78,7 +105,13 @@ func _format_ns(data: HanpekiLogger.MsgData) -> String:
 	return format.replace("{ns}", "[%s]" % data.ns)
 
 
+func _format_stack(data: HanpekiLogger.MsgData) -> String:
+	if !data.stack:
+		return ""
+	return _stack_format.replace("{stack}", _get_stack_str(data))
+
+
 class Options:
 	extends Transport.Options
 	## Whether to use formatting or not
-	var formatting: bool
+	var formatting: bool = true

--- a/addons/hanpeki_godot_logger/transports/logger_file_transport.gd
+++ b/addons/hanpeki_godot_logger/transports/logger_file_transport.gd
@@ -20,8 +20,10 @@ var _file: FileAccess
 ##
 static func create(options: Options = null) -> HanpekiLoggerFileTransport:
 	var instance = HanpekiLoggerFileTransport.new()
+	if !options:
+		options = Options.new()
 	instance.set_options(options)
-	var file_path = DEFAULT_FILE_PATH if options == null else options.file_path
+	var file_path = options.file_path
 	instance._file = _get_file(file_path)
 	return instance
 
@@ -95,4 +97,4 @@ func _notification(what):
 class Options:
 	extends Transport.Options
 	## Path to use for the file to write to
-	var file_path: String
+	var file_path: String = DEFAULT_FILE_PATH

--- a/test/test_static.gd
+++ b/test/test_static.gd
@@ -105,3 +105,49 @@ func test_is_valid_level():
 	assert_false(HanpekiLogger._is_valid_level(60))
 	assert_false(HanpekiLogger._is_valid_level(90))
 	assert_false(HanpekiLogger._is_valid_level(1234567))
+
+
+##
+## Test the proper evaluation of [code]Dictionary[int, StackLevelConfig][/code]
+##
+func test_eval_provide_stack() -> void:
+	var is_debug = OS.is_debug_build()
+	var config: Dictionary[int, HanpekiLogger.StackLevelConfig] = {
+		100: HanpekiLogger.StackLevelConfig.NONE,
+		101: HanpekiLogger.StackLevelConfig.ORIGIN,
+		102: HanpekiLogger.StackLevelConfig.FULL,
+		103: HanpekiLogger.StackLevelConfig.ORIGIN_IF_DEBUG,
+		104: HanpekiLogger.StackLevelConfig.FULL_IF_DEBUG,
+		105: HanpekiLogger.StackLevelConfig.ORIGIN_IF_PROD,
+		106: HanpekiLogger.StackLevelConfig.FULL_IF_PROD,
+	}
+	var expected: Dictionary[int, HanpekiLogger.Transport.StackLevelMode] = {
+		100: HanpekiLogger.Transport.StackLevelMode.NONE,
+		101: HanpekiLogger.Transport.StackLevelMode.ORIGIN,
+		102: HanpekiLogger.Transport.StackLevelMode.FULL,
+		103:
+		(
+			HanpekiLogger.Transport.StackLevelMode.ORIGIN
+			if is_debug
+			else HanpekiLogger.Transport.StackLevelMode.NONE
+		),
+		104:
+		(
+			HanpekiLogger.Transport.StackLevelMode.FULL
+			if is_debug
+			else HanpekiLogger.Transport.StackLevelMode.NONE
+		),
+		105:
+		(
+			HanpekiLogger.Transport.StackLevelMode.ORIGIN
+			if !is_debug
+			else HanpekiLogger.Transport.StackLevelMode.NONE
+		),
+		106:
+		(
+			HanpekiLogger.Transport.StackLevelMode.FULL
+			if !is_debug
+			else HanpekiLogger.Transport.StackLevelMode.NONE
+		),
+	}
+	assert_eq_deep(HanpekiLogger.Transport._eval_provide_stack(config), expected)

--- a/test/utils/hanpeki_test_transport.gd
+++ b/test/utils/hanpeki_test_transport.gd
@@ -13,6 +13,15 @@ var _processed: Dictionary[int, Variant] = {}
 
 
 ##
+## Constructor with [param options]
+##
+static func create(options: Options = null) -> HanpekiLoggerTestTransport:
+	var instance = HanpekiLoggerTestTransport.new()
+	instance.set_options(options)
+	return instance
+
+
+##
 ## [method process] is needed when implementing a [HanpekiLogger.Transport]
 ##
 func process(data: HanpekiLogger.MsgData) -> void:
@@ -49,3 +58,17 @@ func get_processed_message(msg: String, level: int = HanpekiLogger.NONE) -> Hanp
 ##
 func has_processed_message(msg: String, level: int = HanpekiLogger.NONE) -> bool:
 	return get_processed_message(msg, level) != null
+
+
+##
+## Reset the list of processed messages. If a [param level] is given,
+## only the list of processed messages for that level will be reset.
+##
+func reset_processed(level: int = HanpekiLogger.NONE) -> void:
+	if level == HanpekiLogger.NONE:
+		_all_processed.clear()
+		_processed.clear()
+		return
+	if _processed.has(level):
+		_processed[level].clear()
+	_all_processed = _all_processed.filter(func(data) -> bool: return data.level != level)


### PR DESCRIPTION
Transports can now decide if they want to output the stack trace with the `Transport.Options.stack_mode` option.

The logger instance will calculate auto-magically if the stack is nedeed or not based on the added transports (on `instance.add_transport` and `transport.set_options`. For this, when the transport is added the instance adds a reference to itself on the transport, which allows the transport notifying the instance when the options change via `instance.__recalculate_is_stack_needed()` (consider it a protected method :P)